### PR TITLE
Is empty main

### DIFF
--- a/midiFilterMain.cpp
+++ b/midiFilterMain.cpp
@@ -10,7 +10,7 @@
 #include "ext_obex.h"
 #include "ext_strings.h"
 #include "ext_common.h"
-#include "ext_systhread.h"
+//#include "ext_systhread.h"
 #include <array>
 #include <vector>
 using namespace std;
@@ -73,7 +73,7 @@ long    midiFilter_arrayContains(t_midiFilter *x, numberArrayVector &collection,
 void    midiFilter_removeValuesFromArray(t_midiFilter *x, numberArrayVector &collection, long valueToRemove);
 void    midiFilter_version();
 void    midiFilter_printReassigned(t_midiFilter *x);
-//void    midiFilter_isEmpty(t_midiFilter *x, long deviceID);
+void    midiFilter_isEmpty(t_midiFilter *x, long deviceID);
 
 
 // globals
@@ -83,7 +83,7 @@ static t_class    *s_midiFilter_class = NULL;
 
 void ext_main(void *r)
 {
-    t_class    *c = class_new("midiFilter",
+    t_class    *c = class_new("midiFilterMain",
                            (method)midiFilter_new,
                            (method)midiFilter_free,
                            sizeof(t_midiFilter),
@@ -107,13 +107,13 @@ void ext_main(void *r)
     class_addmethod(c, (method)midiFilter_removeValuesFromArray, "int", A_LONG, 0);
     class_addmethod(c, (method)midiFilter_version, "version", 0);
     class_addmethod(c, (method)midiFilter_printReassigned, "printReassigned", 0);
-    //class_addmethod(c, (method)midiFilter_isEmpty, "isEmpty", A_LONG, 0);
+    class_addmethod(c, (method)midiFilter_isEmpty, "isEmpty", A_LONG, 0);
     
 
     class_register(CLASS_BOX, c);
     s_midiFilter_class = c;
     
-    post("midiFilter object 3.0 big-refactor");
+    post("midiFilterMain object 1.0");
 }
 
 
@@ -652,11 +652,26 @@ void midiFilter_printReassigned(t_midiFilter *x)
     
 void midiFilter_version()
 {
-    post("midiFilter object 3.0 big-refactor");
+    post("midiFilterMain object 1.0");
 }
 
-//void midiFilter_isEmpty(t_midiFilter *x, long deviceID)
-//{
-//    post("device ID: %d", deviceID);
-//}
+void midiFilter_isEmpty(t_midiFilter *x, long deviceID)
+{
+    long mainSize = x->m_mainNotes->size();
+    long isEmpty;
+    
+    t_atom *av = NULL;
+    av = new t_atom[2];
+    
+    if (mainSize == 0) {isEmpty = 1;} else {isEmpty = 0;}
+    
+    atom_setlong(av, deviceID);
+    atom_setlong(av + 1, isEmpty);
+    
+    
+    outlet_anything(x->m_outlet2, gensym("isEmpty"), 2, av);
+    
+    post("device ID: %d", deviceID);
+    post("mainSize: %d", mainSize);
+}
 

--- a/midiFilterMain.cpp
+++ b/midiFilterMain.cpp
@@ -73,6 +73,7 @@ long    midiFilter_arrayContains(t_midiFilter *x, numberArrayVector &collection,
 void    midiFilter_removeValuesFromArray(t_midiFilter *x, numberArrayVector &collection, long valueToRemove);
 void    midiFilter_version();
 void    midiFilter_printReassigned(t_midiFilter *x);
+//void    midiFilter_isEmpty(t_midiFilter *x, long deviceID);
 
 
 // globals
@@ -106,6 +107,7 @@ void ext_main(void *r)
     class_addmethod(c, (method)midiFilter_removeValuesFromArray, "int", A_LONG, 0);
     class_addmethod(c, (method)midiFilter_version, "version", 0);
     class_addmethod(c, (method)midiFilter_printReassigned, "printReassigned", 0);
+    //class_addmethod(c, (method)midiFilter_isEmpty, "isEmpty", A_LONG, 0);
     
 
     class_register(CLASS_BOX, c);
@@ -294,8 +296,6 @@ void midiFilter_list(t_midiFilter *x, t_symbol *msg, long argc, t_atom *argv)
             
             // refire if note is already in local and localMath returns a pitch then exit
             
-//            bool localMath = midiFilter_localMath(x, pitch);
-//            post("localMath %ld", localMath);
             
             if (midiFilter_contains(x, *x->m_localNotes, pitch) && midiFilter_localMath(x, pitch)){
                 
@@ -330,7 +330,6 @@ void midiFilter_list(t_midiFilter *x, t_symbol *msg, long argc, t_atom *argv)
                     
                     return;
                     
-                    //else run again with new pitch
                     //UPDATE: refactor-> no need to run again add to lists and to reassigned if > 0 && < 128.
                     
                 } else {
@@ -651,10 +650,13 @@ void midiFilter_printReassigned(t_midiFilter *x)
     }
 }
     
-
-
 void midiFilter_version()
 {
     post("midiFilter object 3.0 big-refactor");
 }
+
+//void midiFilter_isEmpty(t_midiFilter *x, long deviceID)
+//{
+//    post("device ID: %d", deviceID);
+//}
 


### PR DESCRIPTION
added isEmpty method to midiFilterMain. A message is sent to main by local every time a incoming midi note is received to see is mainNotes is empty. If it is the note is added to mainNotes and the note is played by local after an answer from main is received with a selector, "isEmpty" along with device number and a 0 for false or 1 for true. 